### PR TITLE
Add iterator support to radix heap

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -275,7 +275,9 @@ impl<K: Radix + Ord + Copy, V> RadixHeapMap<K,V> {
             bucket.shrink_to_fit();
         }
     }
+}
 
+impl<K, V> RadixHeapMap<K, V> {
     pub fn iter(&self) -> impl Iterator<Item = &(K, V)> {
         self.buckets.iter()
             .flat_map(|b| b.iter())
@@ -333,7 +335,7 @@ impl<'a, K: Radix + Ord + Copy + 'a, V: Copy + 'a> Extend<&'a (K,V)> for RadixHe
 
 impl<K: fmt::Debug, V: fmt::Debug> fmt::Debug for RadixHeapMap<K,V> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let entries = self.buckets.iter().flat_map(|b| b.iter());
+        let entries = self.iter();
         f.debug_list().entries(entries).finish()
     }
 }


### PR DESCRIPTION
Add an iterator over the values, keys, and (key, value)s.  Iterate over the buckets first, and then chain the initial bucket.

- [x] fix bug in `Debug` impl causing no values to show when nothing has been popped (_is this intentional_?) / use iter method to implement `Debug`
- [ ] ~add `IntoIterator` impl~ The `IntoIter` type is really annoying to write, maybe it's not worth it?  I'll look into it again another time perhaps