### PR TITLE
Update ordered-float to fix RUSTSEC-2020-0082

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,7 @@ name = "bench"
 
 [dependencies]
 ieee754 = "0.2.2"
-ordered-float = "1.0.2"
-ordered-float-05 = { package = "ordered-float", version = "0.5.0" }
+ordered-float = "1.1.1"
 
 [dev-dependencies]
 criterion = "0.2.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -582,8 +582,6 @@ macro_rules! radix_float_impl {
 
 radix_float_impl!(f32, ordered_float::NotNan<f32>);
 radix_float_impl!(f64, ordered_float::NotNan<f64>);
-radix_float_impl!(f32, ordered_float_05::NotNaN<f32>);
-radix_float_impl!(f64, ordered_float_05::NotNaN<f64>);
 
 impl Radix for () {
     #[inline]


### PR DESCRIPTION
Remove dependency on ordered-float-05 and ensure the ordered-float 1.x
version is at least 1.1.1.

---

Hi @mpdn!

I really like radix-heap, it's made my Dijkstra's algorithm implementation in [difftastic](https://github.com/wilfred/difftastic) significantly faster :).

I noticed that `cargo audit` has started complaining about the ordered-float version, so this PR upgrades it.