### PR TITLE
switched `RadixHeapMap::push()` to return a Result

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,11 @@ pushpop_binary          time:   [507.28 us 507.44 us 507.60 us]
 # Example
 
 ```
-extern crate radix_heap;
 let mut heap = radix_heap::RadixHeapMap::new();
 
-heap.push(7, 'a');
-heap.push(2, 'b');
-heap.push(9, 'c');
+heap.push(7, 'a').unwrap();
+heap.push(2, 'b').unwrap();
+heap.push(9, 'c').unwrap();
 
 assert!(heap.top() == None);
 assert!(heap.pop() == Some((9, 'c')));

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -174,6 +174,7 @@ impl AStarHeap for RadixHeapMap<Reverse<u32>, (Pos, u32)> {
     #[inline]
     fn push(&mut self, entry: AStarEntry) {
         self.push(Reverse(entry.full_cost), (entry.pos, entry.cost))
+            .unwrap()
     }
 
     #[inline]
@@ -213,13 +214,13 @@ fn pushpop_radix(b: &mut Bencher) {
     let mut heap = RadixHeapMap::<i32, ()>::new();
 
     b.iter(|| {
-        heap.push(0, ());
+        heap.push(0, ()).unwrap();
 
         for _ in 0..10000 {
             let (n, _) = heap.pop().unwrap();
 
             for i in 0..4 {
-                heap.push(n - i, ());
+                heap.push(n - i, ()).unwrap();
             }
         }
 


### PR DESCRIPTION
Switched `RadixHeapMap::push()` to return a Result rather than simply panicking when given a greater key than the current top key.

This is a nicer API to work with as it allows the caller to choose how they want to handle such an error rather than being forced to panic.

The use-case that inspired this change was I was trying to debug a scenario when a greater key was given by catching the faulty `push` and doing some `dbg!()`s but I was unable to since `push()` panics internally.